### PR TITLE
feat: add @UseSerializer for user-definable serializers

### DIFF
--- a/src/main/kotlin/dev/s7a/ktconfig/KtConfigSerializer.kt
+++ b/src/main/kotlin/dev/s7a/ktconfig/KtConfigSerializer.kt
@@ -1,10 +1,6 @@
 package dev.s7a.ktconfig
 
-import kotlin.reflect.KType
-
 interface KtConfigSerializer {
-    val type: KType
-
     fun deserialize(value: Any?): Any?
 
     fun serialize(value: Any?): Any?

--- a/src/main/kotlin/dev/s7a/ktconfig/KtConfigSerializer.kt
+++ b/src/main/kotlin/dev/s7a/ktconfig/KtConfigSerializer.kt
@@ -1,0 +1,11 @@
+package dev.s7a.ktconfig
+
+import kotlin.reflect.KType
+
+interface KtConfigSerializer {
+    val type: KType
+
+    fun deserialize(value: Any?): Any?
+
+    fun serialize(value: Any?): Any?
+}

--- a/src/main/kotlin/dev/s7a/ktconfig/UseSerializer.kt
+++ b/src/main/kotlin/dev/s7a/ktconfig/UseSerializer.kt
@@ -1,0 +1,6 @@
+package dev.s7a.ktconfig
+
+import kotlin.reflect.KClass
+
+@Target(AnnotationTarget.TYPE)
+annotation class UseSerializer(val with: KClass<out KtConfigSerializer>)

--- a/src/main/kotlin/dev/s7a/ktconfig/internal/KtConfigSerialization.kt
+++ b/src/main/kotlin/dev/s7a/ktconfig/internal/KtConfigSerialization.kt
@@ -413,9 +413,7 @@ internal object KtConfigSerialization {
         }
     }
 
-    private fun KType.findSerializer(): KtConfigSerializer? {
-        val serializer = findAnnotation<UseSerializer>()?.with ?: return null
-        println(serializer)
-        return serializer.objectInstance ?: serializer.createInstance()
+    private fun KAnnotatedElement.findSerializer(): KtConfigSerializer? {
+        return findAnnotation<UseSerializer>()?.with?.run { this.objectInstance ?: this.createInstance() }
     }
 }

--- a/src/main/kotlin/dev/s7a/ktconfig/internal/KtConfigSerialization.kt
+++ b/src/main/kotlin/dev/s7a/ktconfig/internal/KtConfigSerialization.kt
@@ -116,9 +116,7 @@ internal object KtConfigSerialization {
     }
 
     private fun deserialize(projectionMap: Map<KTypeParameter, KTypeProjection>, type: KType, value: Any?): Any? {
-        type.findSerializer()?.let {
-            return it.deserialize(deserialize(projectionMap, it.type, value))
-        }
+        type.findSerializer()?.run { return deserialize(value) }
         return when (val classifier = type.classifier) {
             String::class -> value.toString()
             Int::class -> {
@@ -332,9 +330,7 @@ internal object KtConfigSerialization {
 
     private fun serialize(projectionMap: Map<KTypeParameter, KTypeProjection>, section: ConfigurationSection, type: KType, value: Any?): Any? {
         if (value == null) return null
-        type.findSerializer()?.let {
-            return it.serialize(serialize(projectionMap, section, it.type, value))
-        }
+        type.findSerializer()?.run { return serialize(value) }
         return when (val classifier = type.classifier) {
             String::class -> value
             Int::class -> value

--- a/src/main/kotlin/dev/s7a/ktconfig/internal/KtConfigSerialization.kt
+++ b/src/main/kotlin/dev/s7a/ktconfig/internal/KtConfigSerialization.kt
@@ -96,20 +96,22 @@ internal object KtConfigSerialization {
     }
 
     private fun ConfigurationSection.set(clazz: KClass<*>, type: KType, value: Any) {
-        clazz.memberProperties.forEach {
-            if (it.javaField == null) {
-                // Ignore custom getters
-                // https://discuss.kotlinlang.org/t/reflection-and-properties-checking-for-custom-getters-setters/22457/2
-                return@forEach
-            }
-            it.isAccessible = true
-            serialize(projectionMap(clazz, type), createSection(it.name), it.returnType, it.call(value)).run {
-                if (this !is Unit) {
-                    // Unit is that should be ignored
-                    set(it.name, this)
+        projectionMap(clazz, type).run {
+            clazz.memberProperties.forEach {
+                if (it.javaField == null) {
+                    // Ignore custom getters
+                    // https://discuss.kotlinlang.org/t/reflection-and-properties-checking-for-custom-getters-setters/22457/2
+                    return@forEach
                 }
+                it.isAccessible = true
+                serialize(this, createSection(it.name), it.returnType, it.call(value)).run {
+                    if (this !is Unit) {
+                        // Unit is that should be ignored
+                        set(it.name, this)
+                    }
+                }
+                setComment(it.name, it.findComment())
             }
-            setComment(it.name, it.findComment())
         }
     }
 

--- a/src/test/kotlin/UseSerializerTest.kt
+++ b/src/test/kotlin/UseSerializerTest.kt
@@ -1,0 +1,63 @@
+import dev.s7a.ktconfig.KtConfigSerializer
+import dev.s7a.ktconfig.UseSerializer
+import dev.s7a.ktconfig.ktConfigString
+import dev.s7a.ktconfig.saveKtConfigString
+import kotlin.reflect.typeOf
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class UseSerializerTest {
+    private object IntPairStringSerializerObject : KtConfigSerializer {
+        override val type = typeOf<String>()
+
+        override fun deserialize(value: Any?): Any? {
+            if (value !is String) return null
+            return value.split(',').run {
+                if (size != 2) return null
+                val first = this[0].toIntOrNull() ?: return null
+                val second = this[1].toIntOrNull() ?: return null
+                first to second
+            }
+        }
+
+        override fun serialize(value: Any?): Any? {
+            if (value !is Pair<*, *>) return null
+            return "${value.first}, ${value.second}"
+        }
+    }
+
+    private class IntPairStringSerializerClass : KtConfigSerializer {
+        override val type = typeOf<String>()
+
+        override fun deserialize(value: Any?): Any? {
+            if (value !is String) return null
+            return value.split(',').run {
+                if (size != 2) return null
+                val first = this[0].toIntOrNull() ?: return null
+                val second = this[1].toIntOrNull() ?: return null
+                first to second
+            }
+        }
+
+        override fun serialize(value: Any?): Any? {
+            if (value !is Pair<*, *>) return null
+            return "${value.first}, ${value.second}"
+        }
+    }
+
+    @Test
+    fun use_object() {
+        data class Data(val data: @UseSerializer(with = IntPairStringSerializerObject::class) Pair<Int, Int>)
+
+        assertEquals("data: 1, 2\n", saveKtConfigString(Data(1 to 2)))
+        assertEquals(Data(2 to 3), ktConfigString("data: 2, 3"))
+    }
+
+    @Test
+    fun use_class() {
+        data class Data(val data: @UseSerializer(with = IntPairStringSerializerClass::class) Pair<Int, Int>)
+
+        assertEquals("data: 1, 2\n", saveKtConfigString(Data(1 to 2)))
+        assertEquals(Data(2 to 3), ktConfigString("data: 2, 3"))
+    }
+}

--- a/src/test/kotlin/UseSerializerTest.kt
+++ b/src/test/kotlin/UseSerializerTest.kt
@@ -1,53 +1,15 @@
-import dev.s7a.ktconfig.KtConfigSerializer
 import dev.s7a.ktconfig.UseSerializer
 import dev.s7a.ktconfig.ktConfigString
 import dev.s7a.ktconfig.saveKtConfigString
-import kotlin.reflect.typeOf
+import serializer.IntPairStringSerializerClass
+import serializer.IntPairStringSerializerObject
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
 class UseSerializerTest {
-    private object IntPairStringSerializerObject : KtConfigSerializer {
-        override val type = typeOf<String>()
-
-        override fun deserialize(value: Any?): Any? {
-            if (value !is String) return null
-            return value.split(',').run {
-                if (size != 2) return null
-                val first = this[0].toIntOrNull() ?: return null
-                val second = this[1].toIntOrNull() ?: return null
-                first to second
-            }
-        }
-
-        override fun serialize(value: Any?): Any? {
-            if (value !is Pair<*, *>) return null
-            return "${value.first}, ${value.second}"
-        }
-    }
-
-    private class IntPairStringSerializerClass : KtConfigSerializer {
-        override val type = typeOf<String>()
-
-        override fun deserialize(value: Any?): Any? {
-            if (value !is String) return null
-            return value.split(',').run {
-                if (size != 2) return null
-                val first = this[0].toIntOrNull() ?: return null
-                val second = this[1].toIntOrNull() ?: return null
-                first to second
-            }
-        }
-
-        override fun serialize(value: Any?): Any? {
-            if (value !is Pair<*, *>) return null
-            return "${value.first}, ${value.second}"
-        }
-    }
-
     @Test
     fun use_object() {
-        data class Data(val data: @UseSerializer(with = IntPairStringSerializerObject::class) Pair<Int, Int>)
+        data class Data(val data: @UseSerializer(IntPairStringSerializerObject::class) Pair<Int, Int>)
 
         assertEquals("data: 1, 2\n", saveKtConfigString(Data(1 to 2)))
         assertEquals(Data(2 to 3), ktConfigString("data: 2, 3"))
@@ -55,7 +17,7 @@ class UseSerializerTest {
 
     @Test
     fun use_class() {
-        data class Data(val data: @UseSerializer(with = IntPairStringSerializerClass::class) Pair<Int, Int>)
+        data class Data(val data: @UseSerializer(IntPairStringSerializerClass::class) Pair<Int, Int>)
 
         assertEquals("data: 1, 2\n", saveKtConfigString(Data(1 to 2)))
         assertEquals(Data(2 to 3), ktConfigString("data: 2, 3"))

--- a/src/test/kotlin/serializer/IntPairStringSerializer.kt
+++ b/src/test/kotlin/serializer/IntPairStringSerializer.kt
@@ -1,0 +1,37 @@
+package serializer
+
+import dev.s7a.ktconfig.KtConfigSerializer
+
+object IntPairStringSerializerObject : KtConfigSerializer {
+    override fun deserialize(value: Any?): Any? {
+        if (value !is String) return null
+        return value.split(", ").run {
+            if (size != 2) return null
+            val first = this[0].toIntOrNull() ?: return null
+            val second = this[1].toIntOrNull() ?: return null
+            first to second
+        }
+    }
+
+    override fun serialize(value: Any?): Any? {
+        if (value !is Pair<*, *>) return null
+        return "${value.first}, ${value.second}"
+    }
+}
+
+class IntPairStringSerializerClass : KtConfigSerializer {
+    override fun deserialize(value: Any?): Any? {
+        if (value !is String) return null
+        return value.split(", ").run {
+            if (size != 2) return null
+            val first = this[0].toIntOrNull() ?: return null
+            val second = this[1].toIntOrNull() ?: return null
+            first to second
+        }
+    }
+
+    override fun serialize(value: Any?): Any? {
+        if (value !is Pair<*, *>) return null
+        return "${value.first}, ${value.second}"
+    }
+}


### PR DESCRIPTION
The _Special Willpower And Techniques_ (SWAT) team has arrived on scene to handle a high-complexity situation and made a previously unfeasible merge possible. (I'm joking, but it makes for a heck of an introduction, right? :laughing:)

This PR resolves #6 by:

- Rebasing the [`feat/use-serializer`](https://github.com/sya-ri/ktConfig/tree/feat/use-serializer) branch on top of `master`, which entailed resolving conflicts due to divergences and modifying commit [`2802703`](https://github.com/sya-ri/ktConfig/commit/2802703c932689d32741c5c030ec032deb977717).

- Addressing the exception described in #6 by defining custom serializers in their own files. This is necessary to work around a Kotlin Reflect limitation on local classes that has been known for years and ended up causing the described exception. The investigation that led to this conclusion is described in the report below.

  To the best of my knowledge, this is the best possible workaround, as it does not require redesigning or dropping the whole custom serializer feature. Moreover, given proper documentation, I believe that most users won't find it very unpleasant.

- Introducing several minor refactors and performance improvements to the existing code on separate atomic commits. They can be cherry-picked if necessary.

These changes do not modify the documentation because I'm not sure what would be the most appropriate way to do it. Apart from that, I think that there may be room for additional refactors and changes on this feature. But at least its tests pass now (`./gradlew test` completes successfully), which is an important step forward.

<details>
<summary><b>Investigation report (detailed description of what I've found about the issue and how)</b></summary>

Firstly, the issue was deemed feasible to fix because [classes are explicitly supported as annotation parameter types](https://kotlinlang.org/docs/annotations.html#constructors). People usually write documentation with some understanding of the system being documented, and the writer would likely have noticed if it didn't work at all. Moreover, if a system is complex enough to break in strange ways, it usually means it is complex enough for workarounds to exist (this is something I learned through experience :wink:).

After deciding to give the issue a shot, I attempted to reproduce the exception in a debugger, which I managed to do:

![image](https://user-images.githubusercontent.com/7822554/204103238-06addf28-bff0-48f7-a5ad-94065b2f68b5.png)

Examining the stack frame and surrounding code, it stood to reason that the annotation interface instance is a [dynamic proxy](https://docs.oracle.com/javase/8/docs/api/java/lang/reflect/Proxy.html) (remember that annotations are interfaces, so they must be instantiated somehow to be used). This proxy is created so that some hardcoded methods are always supported. Any additional methods, and in particular property getter methods, are only supported if they are present in the `values` parameter of the `createAnnotationInstance` method. In this case, the `values` map is empty, so `values.containsKey(name)` returns `false`, and the exception is thrown.

Naturally, this fact prompts the question: what's going on with the `values` map? It should "support" that method, but somehow it doesn't, and querying a search engine about the problem does not help much. Moreover, the stack trace does not say who instantiated the proxy and passed the `values` map because the proxy methods are called after the map is captured from the stack frame.

Here I had some insight: if a breakpoint is set at the `return result as T` line, where the proxy instance is returned, the stack trace would contain information about the method that called `createAnnotationInstance` and passed an empty `values` map. And indeed it did:

![image](https://user-images.githubusercontent.com/7822554/204104654-0038826c-3de8-44ae-8b78-1ba4c8025be5.png)
![image](https://user-images.githubusercontent.com/7822554/204104662-67820e2f-abc9-4ac7-94ea-6a98bb543b61.png)

`AnnotationDescriptor.toAnnotationInstance()` is closer to the source of the problem! The `values` map is generated from the `AnnotationDescriptor.allValuesArgument` property, [which has a simple implementation that looks correct](https://github.com/JetBrains/kotlin/blob/4af32b8d3642752a4c2ecbb1a97f6f54440d8491/core/descriptors/src/org/jetbrains/kotlin/descriptors/annotations/AnnotationDescriptorImpl.java#L60-L62). Moreover, the `KClassValue` class implements `ConstantValue` with no flaws for this purpose, meaning that Kotlin classes should have first-class support for being used in annotation descriptors. Most likely, what's wreaking havoc is the `value.toRuntimeValue` return value: that method can return a `null` value, and `null`s are filtered out.

Things start getting ugly when looking at the `toRuntimeValue` method implementation, with has a fair share of `TODO` comments:

![image](https://user-images.githubusercontent.com/7822554/204105163-90aaf8b7-b053-4a7b-a3fc-7313dde13478.png)

As I've asserted before, Kotlin class annotation values are represented by instances of `KClassValue`, which are explicitly handled by `toRuntimeValue`. Unluckily for us, however, `KClassValue`s are further classified into values that represent "normal classes" and "local classes" (i.e., classes that are local to another class, like `IntPairStringSerializerClass` was to the test code at `UseSerializerTest`). And local classes are affected by a blatant `TODO` comment stating that "this doesn't work", referring to [KT-30013](https://youtrack.jetbrains.com/issue/KT-30013), a four year old issue that nobody seems interested on.

I don't know why someone thought that adding such a `TODO` comment was better than throwing an exception, as the latter would motivate a fix and facilitate debugging: the stack trace of the resulting exception would be more meaningful and have a better message. But the root cause is clear now: `ConstantValue<*>.toRuntimeValue` returns `null` for local classes in annotation descriptors, so local classes can't be used there. Fortunately, refactoring a local class into a "normal class" is easy to do.
</details>