### PR TITLE
[codex] Release v2.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## v2.1.1
+
+### Added
+- Added a distributable `ktconfig` agent skill under `skills/ktconfig`.
+  - Includes installation metadata for agent tools.
+  - Includes a focused reference covering annotations, generated loaders, serializers, sealed classes, and KSP usage notes.
+
 ## v2.1.0
 
 ### Added

--- a/LLM.txt
+++ b/LLM.txt
@@ -16,7 +16,7 @@ Key characteristics:
 - Annotate a data class with `@KtConfig` → KSP generates `<ClassName>Loader` (e.g. `ServerConfigLoader`)
 - The loader reads/writes a YAML file using Bukkit's `YamlConfiguration`
 - Supports Kotlin default values, nullable types, sealed classes/interfaces, and custom serializers
-- Latest stable version: **2.1.0**
+- Latest stable version: **2.1.1**
 
 ---
 
@@ -35,8 +35,8 @@ repositories {
 }
 
 dependencies {
-    implementation("dev.s7a:ktConfig:2.1.0")
-    ksp("dev.s7a:ktConfig-ksp:2.1.0")
+    implementation("dev.s7a:ktConfig:2.1.1")
+    ksp("dev.s7a:ktConfig-ksp:2.1.1")
 }
 ```
 
@@ -1018,6 +1018,7 @@ dev.s7a.ktconfig
 
 | Version | Notable Changes |
 |---|---|
+| 2.1.1 | Distributable `ktconfig` agent skill under `skills/ktconfig` |
 | 2.1.0 | Sealed classes/interfaces, `@SerialName` (replaces `@PathName`), `loaderName`, `loadAndSave`, `loadAndSaveIfNotExists`, `saveIfNotExists`, BigInteger/BigDecimal fix, alpha color fix |
 | 2.0.0 | Initial release |
 

--- a/README.md
+++ b/README.md
@@ -27,8 +27,8 @@ repositories {
 }
 
 dependencies {
-    implementation("dev.s7a:ktConfig:2.1.0")
-    ksp("dev.s7a:ktConfig-ksp:2.1.0")
+    implementation("dev.s7a:ktConfig:2.1.1")
+    ksp("dev.s7a:ktConfig-ksp:2.1.1")
 }
 ```
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -14,7 +14,7 @@ plugins {
 }
 
 group = "dev.s7a"
-version = "2.1.0"
+version = "2.1.1"
 
 allprojects {
     apply(plugin = "kotlin")

--- a/skills/ktconfig/references/ktconfig-reference.md
+++ b/skills/ktconfig/references/ktconfig-reference.md
@@ -24,8 +24,8 @@ repositories {
 }
 
 dependencies {
-    implementation("dev.s7a:ktConfig:2.1.0")
-    ksp("dev.s7a:ktConfig-ksp:2.1.0")
+    implementation("dev.s7a:ktConfig:2.1.1")
+    ksp("dev.s7a:ktConfig-ksp:2.1.1")
 }
 ```
 


### PR DESCRIPTION
## Summary
- bump project version to `2.1.1`
- add release notes for the new distributable `ktconfig` agent skill
- update published documentation snippets to reference `2.1.1`

## Why
This release is intended to ship the newly added `skills/ktconfig` skill as a patch release without changing the runtime library surface.

## Impact
Users can install and use the `ktconfig` agent skill, and the repository documentation now points at the matching `2.1.1` release version.

## Validation
- reviewed the release diff locally
- no runtime or test-impacting source changes were included
