### PR TITLE
Fix multiline comments for v2.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v2.1.2
+
+### Fixed
+- Fixed generated loaders for `@Comment` values written as Kotlin raw strings.
+
 ## v2.1.1
 
 ### Added

--- a/LLM.txt
+++ b/LLM.txt
@@ -16,7 +16,7 @@ Key characteristics:
 - Annotate a data class with `@KtConfig` → KSP generates `<ClassName>Loader` (e.g. `ServerConfigLoader`)
 - The loader reads/writes a YAML file using Bukkit's `YamlConfiguration`
 - Supports Kotlin default values, nullable types, sealed classes/interfaces, and custom serializers
-- Latest stable version: **2.1.1**
+- Latest stable version: **2.1.2**
 
 ---
 
@@ -35,8 +35,8 @@ repositories {
 }
 
 dependencies {
-    implementation("dev.s7a:ktConfig:2.1.1")
-    ksp("dev.s7a:ktConfig-ksp:2.1.1")
+    implementation("dev.s7a:ktConfig:2.1.2")
+    ksp("dev.s7a:ktConfig-ksp:2.1.2")
 }
 ```
 
@@ -1018,6 +1018,7 @@ dev.s7a.ktconfig
 
 | Version | Notable Changes |
 |---|---|
+| 2.1.2 | Raw string support for `@Comment` values in generated loaders |
 | 2.1.1 | Distributable `ktconfig` agent skill under `skills/ktconfig` |
 | 2.1.0 | Sealed classes/interfaces, `@SerialName` (replaces `@PathName`), `loaderName`, `loadAndSave`, `loadAndSaveIfNotExists`, `saveIfNotExists`, BigInteger/BigDecimal fix, alpha color fix |
 | 2.0.0 | Initial release |

--- a/README.md
+++ b/README.md
@@ -27,8 +27,8 @@ repositories {
 }
 
 dependencies {
-    implementation("dev.s7a:ktConfig:2.1.1")
-    ksp("dev.s7a:ktConfig-ksp:2.1.1")
+    implementation("dev.s7a:ktConfig:2.1.2")
+    ksp("dev.s7a:ktConfig-ksp:2.1.2")
 }
 ```
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -14,7 +14,7 @@ plugins {
 }
 
 group = "dev.s7a"
-version = "2.1.1"
+version = "2.1.2"
 
 allprojects {
     apply(plugin = "kotlin")

--- a/ksp/src/main/kotlin/dev/s7a/ktconfig/ksp/KotlinPoetHelpers.kt
+++ b/ksp/src/main/kotlin/dev/s7a/ktconfig/ksp/KotlinPoetHelpers.kt
@@ -7,7 +7,15 @@ import com.squareup.kotlinpoet.buildCodeBlock
 /**
  * ["element1", "element2"] -> 'listOf("element1", "element2")'
  */
-fun List<String>.asLiteralList() = "listOf(${joinToString(", ") { "\"$it\"" } })"
+fun List<String>.asLiteralList() =
+    buildCodeBlock {
+        add("listOf(")
+        forEachIndexed { index, value ->
+            if (index > 0) add(", ")
+            add("%S", value)
+        }
+        add(")")
+    }
 
 inline fun FunSpec.Builder.addControlFlowCode(
     controlFlow: String,

--- a/ksp/src/main/kotlin/dev/s7a/ktconfig/ksp/KtConfigAnnotation.kt
+++ b/ksp/src/main/kotlin/dev/s7a/ktconfig/ksp/KtConfigAnnotation.kt
@@ -55,7 +55,14 @@ data class KtConfigAnnotation(
                     val content = arguments["content"] as? List<*> ?: return@firstNotNullOfOrNull null
                     if (content.isEmpty()) return@firstNotNullOfOrNull null
                     if (content.first() !is String) return@firstNotNullOfOrNull null
-                    Comment(content.map(Any?::toString))
+                    Comment(content.flatMap { it.toString().asCommentLines() })
+                }
+
+            private fun String.asCommentLines() =
+                if (lineSequence().count() > 1) {
+                    trimIndent().lines()
+                } else {
+                    listOf(this)
                 }
         }
     }

--- a/skills/ktconfig/references/ktconfig-reference.md
+++ b/skills/ktconfig/references/ktconfig-reference.md
@@ -24,8 +24,8 @@ repositories {
 }
 
 dependencies {
-    implementation("dev.s7a:ktConfig:2.1.1")
-    ksp("dev.s7a:ktConfig-ksp:2.1.1")
+    implementation("dev.s7a:ktConfig:2.1.2")
+    ksp("dev.s7a:ktConfig-ksp:2.1.2")
 }
 ```
 

--- a/src/test/kotlin/LoaderNameTest.kt
+++ b/src/test/kotlin/LoaderNameTest.kt
@@ -52,4 +52,31 @@ class LoaderNameTest {
             actual,
         )
     }
+
+    @Test
+    fun testRawStringComment() {
+        val actual =
+            RawStringCommentConfigLoader.saveToString(
+                RawStringCommentConfig(
+                    updaterDelay = "1h",
+                    message = "test",
+                ),
+            )
+
+        assertEquals(
+            listOf(
+                "# Header line",
+                "# Header default",
+                "",
+                "# The amount of time to pass until a new update check occurs.",
+                "# Default: 1h",
+                "updaterDelay: 1h",
+                "# Line one",
+                "# Line two",
+                "message: test",
+                "",
+            ).joinToString("\n"),
+            actual,
+        )
+    }
 }

--- a/src/test/kotlin/ServerConfig.kt
+++ b/src/test/kotlin/ServerConfig.kt
@@ -1,3 +1,4 @@
+import dev.s7a.ktconfig.Comment
 import dev.s7a.ktconfig.KtConfig
 
 @KtConfig
@@ -9,3 +10,22 @@ data class ServerConfig(
         val serverName: String,
     )
 }
+
+@KtConfig
+@Comment(
+    """
+    Header line
+    Header default
+    """,
+)
+data class RawStringCommentConfig(
+    @Comment(
+        """
+        The amount of time to pass until a new update check occurs.
+        Default: 1h
+        """,
+    )
+    val updaterDelay: String,
+    @Comment("Line one\nLine two")
+    val message: String,
+)


### PR DESCRIPTION
## Summary
- Fix generated loaders for `@Comment` values that contain newlines, including Kotlin raw strings.
- Generate comment lists through KotlinPoet string literals so multiline/comment text is emitted as valid Kotlin.
- Bump release metadata and docs to `2.1.2` with a changelog entry.

## Behavior
A raw string comment such as:

```kotlin
@Comment("""
    Line one
    Line two
""")
```

is generated as separate comment lines and is saved to YAML as:

```yaml
# Line one
# Line two
key: value
```

Plain strings containing `\n` are handled the same way.

Fixes #298

## Validation
- `./gradlew --gradle-user-home .gradle/user-home check`
