### PR TITLE
Fix publish signing key handling

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,7 +5,6 @@ on:
 env:
   ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
   ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.MAVEN_CENTRAL_PASSWORD }}
-  ORG_GRADLE_PROJECT_signingInMemoryKey: ${{ secrets.SIGNING_KEY }}
   ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ secrets.SIGNING_PASSWORD }}
 
 jobs:
@@ -21,5 +20,8 @@ jobs:
           java-version: 21
           cache: gradle
       - name: Publish
+        env:
+          SIGNING_KEY: ${{ secrets.SIGNING_KEY }}
         run: |
+          export ORG_GRADLE_PROJECT_signingInMemoryKey="${SIGNING_KEY//\\n/$'\n'}"
           ./gradlew publish --no-daemon --stacktrace


### PR DESCRIPTION
## Summary
- Normalize escaped newlines in the `SIGNING_KEY` secret before passing it to Gradle signing.
- Restores the newline handling that existed in the previous publishing setup.

## Context
The v2.1.2 publish run failed in `:signMavenPublication` with `Could not read PGP secret key`, because the signing key was passed directly to `signingInMemoryKey` without converting `\n` to real newlines.

## Validation
- `git diff --check`
