### PR TITLE
chore: sync README versions from version catalog

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,12 +4,22 @@ on:
     branches:
       - master
   pull_request:
+permissions:
+  contents: read
 jobs:
   build:
     runs-on: ubuntu-latest
     steps:
       - name: Clone repository
         uses: actions/checkout@v7
+      - name: Setup Python
+        uses: actions/setup-python@v7
+        with:
+          python-version: '3.13'
+      - name: Test README version sync
+        run: python -m unittest discover -s scripts/tests
+      - name: Check README versions
+        run: python scripts/sync_readme_versions.py --check
       - name: Setup java
         uses: actions/setup-java@v5
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -93,6 +93,10 @@ fabric.properties
 # Compiled class file
 *.class
 
+### Python ###
+__pycache__/
+*.py[cod]
+
 # Log file
 *.log
 

--- a/README.md
+++ b/README.md
@@ -19,8 +19,8 @@ Add the following dependencies to your `build.gradle.kts`
 
 ```kotlin
 plugins {
-    kotlin("jvm") version "2.2.21"
-    id("com.google.devtools.ksp") version "2.3.2"
+    kotlin("jvm") version "2.4.10"
+    id("com.google.devtools.ksp") version "2.3.11"
 }
 
 repositories {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -15,7 +15,7 @@ plugins {
 }
 
 group = "dev.s7a"
-version = "2.3.0-SNAPSHOT"
+version = libs.versions.ktConfig.get()
 
 val testJarDir = providers.systemProperty("ktconfig.testJarDir").orNull
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,4 +1,12 @@
 [versions]
+# Project
+# Use a non-SNAPSHOT value before running the publish workflow.
+ktConfig = "2.3.0-SNAPSHOT"
+
+# README dependency examples
+ktConfigBukkit = "2.2.0"
+ktConfigFabric = "2.3.0"
+
 # Plugins
 kotlin = "2.4.10"
 ksp = "2.3.11"
@@ -18,6 +26,9 @@ paper = "1.21.11-R0.1-SNAPSHOT"
 mockbukkit = "4.108.0"
 adventure = "4.26.1"
 configurate = "4.2.0"
+# Configurate runtime pieces included explicitly in the Fabric README example
+geantyref = "1.3.16"
+option = "1.1.0"
 fabricLoader = "0.18.6"
 fabricLoom = "1.17.19"
 
@@ -45,4 +56,8 @@ paper-api = { group = "io.papermc.paper", name = "paper-api", version.ref = "pap
 mockbukkit = { group = "org.mockbukkit.mockbukkit", name = "mockbukkit-v1.21", version.ref = "mockbukkit" }
 adventure-api = { group = "net.kyori", name = "adventure-api", version.ref = "adventure" }
 configurate-yaml = { group = "org.spongepowered", name = "configurate-yaml", version.ref = "configurate" }
+# Fabric README include entries
+configurate-core = { group = "org.spongepowered", name = "configurate-core", version.ref = "configurate" }
+geantyref = { group = "io.leangen.geantyref", name = "geantyref", version.ref = "geantyref" }
+option = { group = "net.kyori", name = "option", version.ref = "option" }
 fabric-loader = { group = "net.fabricmc", name = "fabric-loader", version.ref = "fabricLoader" }

--- a/scripts/sync_readme_versions.py
+++ b/scripts/sync_readme_versions.py
@@ -1,0 +1,304 @@
+#!/usr/bin/env python3
+"""Synchronize README dependency versions with the Gradle version catalog."""
+
+from __future__ import annotations
+
+import argparse
+import difflib
+import os
+import re
+import stat
+import sys
+import tempfile
+import tomllib
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Sequence
+
+
+ROOT_DIRECTORY = Path(__file__).resolve().parents[1]
+DEFAULT_CATALOG = ROOT_DIRECTORY / "gradle" / "libs.versions.toml"
+DEFAULT_README = ROOT_DIRECTORY / "README.md"
+
+
+class SynchronizationError(Exception):
+    """Raised when a catalog key or README target cannot be synchronized safely."""
+
+
+@dataclass(frozen=True)
+class Rule:
+    """Describes one fail-closed replacement inside a Markdown section."""
+
+    name: str
+    section: str
+    pattern: re.Pattern[str]
+    version_key: str
+    expected_matches: int
+
+
+SECTION_PATTERNS = {
+    "installation": (
+        re.compile(r"^## 📦 Installation[ \t]*\r?$", re.MULTILINE),
+        re.compile(r"^### Fabric[ \t]*\r?$", re.MULTILINE),
+    ),
+    "fabric": (
+        re.compile(r"^### Fabric[ \t]*\r?$", re.MULTILINE),
+        re.compile(r"^##(?!#)\s", re.MULTILINE),
+    ),
+}
+
+
+RULES = (
+    Rule(
+        name="Kotlin plugin",
+        section="installation",
+        pattern=re.compile(r'kotlin\("jvm"\)\s+version\s+"(?P<version>[^"\r\n]+)"'),
+        version_key="kotlin",
+        expected_matches=1,
+    ),
+    Rule(
+        name="KSP plugin",
+        section="installation",
+        pattern=re.compile(r'id\("com\.google\.devtools\.ksp"\)\s+version\s+"(?P<version>[^"\r\n]+)"'),
+        version_key="ksp",
+        expected_matches=1,
+    ),
+    Rule(
+        name="Bukkit ktConfig runtime",
+        section="installation",
+        pattern=re.compile(r'dev\.s7a:ktConfig:(?P<version>[^"\r\n]+)'),
+        version_key="ktConfigBukkit",
+        expected_matches=1,
+    ),
+    Rule(
+        name="Bukkit ktConfig KSP",
+        section="installation",
+        pattern=re.compile(r'dev\.s7a:ktConfig-ksp:(?P<version>[^"\r\n]+)'),
+        version_key="ktConfigBukkit",
+        expected_matches=1,
+    ),
+    Rule(
+        name="Fabric ktConfig KSP",
+        section="fabric",
+        pattern=re.compile(r'dev\.s7a:ktConfig-ksp:(?P<version>[^"\r\n]+)'),
+        version_key="ktConfigFabric",
+        expected_matches=1,
+    ),
+    Rule(
+        name="Fabric ktConfig runtime",
+        section="fabric",
+        pattern=re.compile(r'dev\.s7a:ktConfig-fabric:(?P<version>[^"\r\n]+)'),
+        version_key="ktConfigFabric",
+        expected_matches=1,
+    ),
+    Rule(
+        name="Fabric Minecraft adapter",
+        section="fabric",
+        pattern=re.compile(
+            r'dev\.s7a:ktConfig-fabric-minecraft-[^:"\r\n]+:(?P<version>[^"\r\n]+)'
+        ),
+        version_key="ktConfigFabric",
+        expected_matches=1,
+    ),
+    Rule(
+        name="Configurate YAML artifact",
+        section="fabric",
+        pattern=re.compile(r'org\.spongepowered:configurate-yaml:(?P<version>[^"\r\n]+)'),
+        version_key="configurate",
+        expected_matches=1,
+    ),
+    Rule(
+        name="Configurate core artifact",
+        section="fabric",
+        pattern=re.compile(r'org\.spongepowered:configurate-core:(?P<version>[^"\r\n]+)'),
+        version_key="configurate",
+        expected_matches=1,
+    ),
+    Rule(
+        name="geantyref artifact",
+        section="fabric",
+        pattern=re.compile(r'io\.leangen\.geantyref:geantyref:(?P<version>[^"\r\n]+)'),
+        version_key="geantyref",
+        expected_matches=1,
+    ),
+    Rule(
+        name="Option artifact",
+        section="fabric",
+        pattern=re.compile(r'net\.kyori:option:(?P<version>[^"\r\n]+)'),
+        version_key="option",
+        expected_matches=1,
+    ),
+)
+
+
+def read_utf8(path: Path) -> str:
+    """Read UTF-8 without normalizing line endings."""
+
+    return path.read_bytes().decode("utf-8")
+
+
+def load_versions(path: Path) -> dict[str, str]:
+    """Load and validate the version strings required by the README rules."""
+
+    document = tomllib.loads(read_utf8(path))
+    versions = document.get("versions")
+    if not isinstance(versions, dict):
+        raise SynchronizationError(f"{path} does not contain a [versions] table")
+
+    required_keys = {rule.version_key for rule in RULES} | {"ktConfig"}
+    result: dict[str, str] = {}
+    for key in sorted(required_keys):
+        value = versions.get(key)
+        if not isinstance(value, str) or not value:
+            raise SynchronizationError(f"[versions].{key} must be a non-empty string in {path}")
+        result[key] = value
+
+    for key in ("ktConfigBukkit", "ktConfigFabric"):
+        if result[key].endswith("-SNAPSHOT"):
+            raise SynchronizationError(f"[versions].{key} must be a consumer-facing, non-SNAPSHOT version")
+
+    project_version = result["ktConfig"]
+    if not project_version.endswith("-SNAPSHOT"):
+        mismatched_keys = [
+            key
+            for key in ("ktConfigBukkit", "ktConfigFabric")
+            if result[key] != project_version
+        ]
+        if mismatched_keys:
+            keys = ", ".join(f"[versions].{key}" for key in mismatched_keys)
+            raise SynchronizationError(
+                f"release project version {project_version} must match {keys} before publishing"
+            )
+    return result
+
+
+def section_bounds(text: str, section: str) -> tuple[int, int]:
+    """Locate a README section and fail if its boundary is ambiguous."""
+
+    start_pattern, end_pattern = SECTION_PATTERNS[section]
+    starts = list(start_pattern.finditer(text))
+    if len(starts) != 1:
+        raise SynchronizationError(
+            f"README section {section!r} must have exactly one start heading; found {len(starts)}"
+        )
+
+    start = starts[0].start()
+    end_match = end_pattern.search(text, starts[0].end())
+    if end_match is None:
+        raise SynchronizationError(f"README section {section!r} has no end heading")
+    return start, end_match.start()
+
+
+def replace_rule(text: str, versions: dict[str, str], rule: Rule) -> str:
+    """Apply one rule after validating its exact occurrence count."""
+
+    start, end = section_bounds(text, rule.section)
+    section = text[start:end]
+    matches = list(rule.pattern.finditer(section))
+    if len(matches) != rule.expected_matches:
+        raise SynchronizationError(
+            f"{rule.name} must match {rule.expected_matches} time(s) in the "
+            f"{rule.section} section; found {len(matches)}"
+        )
+
+    replacement_version = versions[rule.version_key]
+    if not replacement_version:
+        raise SynchronizationError(f"{rule.name} resolved to an empty version")
+
+    def replace(match: re.Match[str]) -> str:
+        relative_start = match.start("version") - match.start()
+        relative_end = match.end("version") - match.start()
+        return match.group(0)[:relative_start] + replacement_version + match.group(0)[relative_end:]
+
+    updated_section = rule.pattern.sub(replace, section)
+    return text[:start] + updated_section + text[end:]
+
+
+def synchronize_text(readme: str, versions: dict[str, str]) -> str:
+    """Return README content synchronized by every declared rule."""
+
+    updated = readme
+    for rule in RULES:
+        updated = replace_rule(updated, versions, rule)
+    return updated
+
+
+def atomic_write(path: Path, content: str) -> None:
+    """Replace a file atomically while preserving its permission bits."""
+
+    mode = stat.S_IMODE(path.stat().st_mode)
+    descriptor, temporary_name = tempfile.mkstemp(prefix=f".{path.name}.", dir=path.parent)
+    temporary_path = Path(temporary_name)
+    try:
+        with os.fdopen(descriptor, "wb") as temporary_file:
+            temporary_file.write(content.encode("utf-8"))
+        os.chmod(temporary_path, mode)
+        os.replace(temporary_path, path)
+    finally:
+        temporary_path.unlink(missing_ok=True)
+
+
+def unified_diff(path: Path, original: str, updated: str) -> str:
+    """Create a stable, readable diff independent of source line endings."""
+
+    lines = difflib.unified_diff(
+        original.splitlines(),
+        updated.splitlines(),
+        fromfile=str(path),
+        tofile=str(path),
+        lineterm="",
+    )
+    return "\n".join(lines)
+
+
+def run(*, check: bool, catalog_path: Path, readme_path: Path) -> int:
+    """Check or write the synchronized README and return a process exit code."""
+
+    versions = load_versions(catalog_path)
+    original = read_utf8(readme_path)
+    updated = synchronize_text(original, versions)
+
+    if original == updated:
+        print(f"{readme_path} is synchronized with {catalog_path}.")
+        return 0
+
+    if check:
+        print(f"{readme_path} is not synchronized with {catalog_path}.", file=sys.stderr)
+        print("Run: python scripts/sync_readme_versions.py --write", file=sys.stderr)
+        print(unified_diff(readme_path, original, updated), file=sys.stderr)
+        return 1
+
+    atomic_write(readme_path, updated)
+    print(f"Updated {readme_path} from {catalog_path}.")
+    return 0
+
+
+def create_parser() -> argparse.ArgumentParser:
+    """Create the command-line parser."""
+
+    parser = argparse.ArgumentParser(description=__doc__)
+    mode = parser.add_mutually_exclusive_group(required=True)
+    mode.add_argument("--check", action="store_true", help="fail if README.md is out of date")
+    mode.add_argument("--write", action="store_true", help="update README.md in place")
+    parser.add_argument("--catalog", type=Path, default=DEFAULT_CATALOG)
+    parser.add_argument("--readme", type=Path, default=DEFAULT_README)
+    return parser
+
+
+def main(arguments: Sequence[str] | None = None) -> int:
+    """Run the command-line interface."""
+
+    options = create_parser().parse_args(arguments)
+    try:
+        return run(
+            check=options.check,
+            catalog_path=options.catalog.resolve(),
+            readme_path=options.readme.resolve(),
+        )
+    except (OSError, UnicodeError, tomllib.TOMLDecodeError, SynchronizationError) as error:
+        print(f"error: {error}", file=sys.stderr)
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/tests/test_sync_readme_versions.py
+++ b/scripts/tests/test_sync_readme_versions.py
@@ -1,0 +1,182 @@
+from __future__ import annotations
+
+import contextlib
+import io
+import tempfile
+import unittest
+from pathlib import Path
+
+from scripts.sync_readme_versions import (
+    SynchronizationError,
+    load_versions,
+    main,
+    synchronize_text,
+)
+
+
+CATALOG = """\
+[versions]
+ktConfig = "2.3.0-SNAPSHOT"
+ktConfigBukkit = "2.2.0"
+ktConfigFabric = "2.3.0"
+kotlin = "2.4.10"
+ksp = "2.3.11"
+configurate = "4.2.0"
+geantyref = "1.3.16"
+option = "1.1.0"
+"""
+
+README = """\
+# Project\r
+\r
+## 📦 Installation\r
+\r
+```kotlin\r
+kotlin("jvm") version "0.0.1"\r
+id("com.google.devtools.ksp") version "0.0.2"\r
+implementation("dev.s7a:ktConfig:0.0.3")\r
+ksp("dev.s7a:ktConfig-ksp:0.0.3")\r
+```\r
+\r
+### Fabric\r
+\r
+```kotlin\n
+ksp("dev.s7a:ktConfig-ksp:0.0.4")\n
+include(implementation("dev.s7a:ktConfig-fabric:0.0.4")!!)\n
+include(implementation("org.spongepowered:configurate-yaml:0.0.5")!!)\n
+include(implementation("org.spongepowered:configurate-core:0.0.5")!!)\n
+include(implementation("io.leangen.geantyref:geantyref:0.0.6")!!)\n
+include(implementation("net.kyori:option:0.0.7")!!)\n
+implementation("dev.s7a:ktConfig-fabric-minecraft-1.21.11:0.0.4")\n
+```\n
+\n
+## Next\n
+"""
+
+
+class SynchronizeReadmeVersionsTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temporary_directory = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temporary_directory.cleanup)
+        self.directory = Path(self.temporary_directory.name)
+        self.catalog_path = self.directory / "libs.versions.toml"
+        self.readme_path = self.directory / "README.md"
+        self.catalog_path.write_bytes(CATALOG.encode())
+        self.readme_path.write_bytes(README.encode())
+
+    def versions(self) -> dict[str, str]:
+        return load_versions(self.catalog_path)
+
+    def test_synchronizes_all_declared_versions_and_preserves_line_endings(self) -> None:
+        updated = synchronize_text(README, self.versions())
+
+        self.assertIn('kotlin("jvm") version "2.4.10"', updated)
+        self.assertIn('id("com.google.devtools.ksp") version "2.3.11"', updated)
+        self.assertEqual(updated.count("dev.s7a:ktConfig:2.2.0"), 1)
+        self.assertEqual(updated.count("dev.s7a:ktConfig-ksp:2.2.0"), 1)
+        self.assertEqual(updated.count("dev.s7a:ktConfig-ksp:2.3.0"), 1)
+        self.assertEqual(updated.count("dev.s7a:ktConfig-fabric:2.3.0"), 1)
+        self.assertEqual(updated.count("dev.s7a:ktConfig-fabric-minecraft-1.21.11:2.3.0"), 1)
+        self.assertEqual(updated.count("org.spongepowered:configurate-yaml:4.2.0"), 1)
+        self.assertEqual(updated.count("org.spongepowered:configurate-core:4.2.0"), 1)
+        self.assertIn("io.leangen.geantyref:geantyref:1.3.16", updated)
+        self.assertIn("net.kyori:option:1.1.0", updated)
+        self.assertEqual(updated.count("\r\n"), README.count("\r\n"))
+        self.assertEqual(updated.count("\n"), README.count("\n"))
+
+    def test_synchronization_is_idempotent(self) -> None:
+        synchronized = synchronize_text(README, self.versions())
+        self.assertEqual(synchronize_text(synchronized, self.versions()), synchronized)
+
+    def test_development_version_does_not_leak_into_dependency_examples(self) -> None:
+        self.catalog_path.write_bytes(CATALOG.replace("2.3.0-SNAPSHOT", "2.4.0-SNAPSHOT").encode())
+        updated = synchronize_text(README, self.versions())
+
+        self.assertNotIn("2.4.0", updated)
+        self.assertEqual(updated.count("dev.s7a:ktConfig-fabric:2.3.0"), 1)
+
+    def test_fails_closed_when_a_readme_target_is_missing(self) -> None:
+        incomplete = README.replace(
+            'include(implementation("net.kyori:option:0.0.7")!!)\n',
+            "",
+        )
+        with self.assertRaisesRegex(SynchronizationError, "Option artifact must match 1 time"):
+            synchronize_text(incomplete, self.versions())
+
+    def test_fails_closed_when_a_readme_target_is_duplicated(self) -> None:
+        duplicated = README.replace(
+            "## Next\n",
+            'include(implementation("net.kyori:option:9.9.9")!!)\n## Next\n',
+        )
+        with self.assertRaisesRegex(SynchronizationError, "Option artifact must match 1 time"):
+            synchronize_text(duplicated, self.versions())
+
+    def test_fails_closed_when_one_artifact_replaces_another(self) -> None:
+        swapped = README.replace("dev.s7a:ktConfig-ksp:0.0.3", "dev.s7a:ktConfig:0.0.3")
+        with self.assertRaisesRegex(SynchronizationError, "Bukkit ktConfig runtime must match 1 time"):
+            synchronize_text(swapped, self.versions())
+
+    def test_requires_every_catalog_key(self) -> None:
+        self.catalog_path.write_bytes(CATALOG.replace('option = "1.1.0"\n', "").encode())
+        with self.assertRaisesRegex(SynchronizationError, r"\[versions\]\.option"):
+            load_versions(self.catalog_path)
+
+    def test_release_project_version_requires_matching_documentation_versions(self) -> None:
+        self.catalog_path.write_bytes(CATALOG.replace("2.3.0-SNAPSHOT", "2.3.0").encode())
+        with self.assertRaisesRegex(SynchronizationError, "release project version 2.3.0"):
+            load_versions(self.catalog_path)
+
+    def test_release_project_version_accepts_matching_documentation_versions(self) -> None:
+        release_catalog = CATALOG.replace("2.3.0-SNAPSHOT", "2.3.0").replace(
+            'ktConfigBukkit = "2.2.0"',
+            'ktConfigBukkit = "2.3.0"',
+        )
+        self.catalog_path.write_bytes(release_catalog.encode())
+        self.assertEqual(load_versions(self.catalog_path)["ktConfig"], "2.3.0")
+
+    def test_check_mode_reports_diff_without_writing(self) -> None:
+        original = self.readme_path.read_bytes()
+        standard_error = io.StringIO()
+        with contextlib.redirect_stderr(standard_error):
+            exit_code = main(
+                [
+                    "--check",
+                    "--catalog",
+                    str(self.catalog_path),
+                    "--readme",
+                    str(self.readme_path),
+                ]
+            )
+
+        self.assertEqual(exit_code, 1)
+        self.assertEqual(self.readme_path.read_bytes(), original)
+        self.assertIn("Run: python scripts/sync_readme_versions.py --write", standard_error.getvalue())
+
+    def test_write_mode_is_byte_idempotent(self) -> None:
+        first_exit_code = main(
+            [
+                "--write",
+                "--catalog",
+                str(self.catalog_path),
+                "--readme",
+                str(self.readme_path),
+            ]
+        )
+        first_write = self.readme_path.read_bytes()
+        second_exit_code = main(
+            [
+                "--write",
+                "--catalog",
+                str(self.catalog_path),
+                "--readme",
+                str(self.readme_path),
+            ]
+        )
+
+        self.assertEqual(first_exit_code, 0)
+        self.assertEqual(second_exit_code, 0)
+        self.assertEqual(self.readme_path.read_bytes(), first_write)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- move the project version and README dependency example versions into gradle/libs.versions.toml
- add a fail-closed README synchronization script with check/write modes and 11 unit tests
- run the tests and synchronization check inside the required Build job with read-only permissions
- update the stale Kotlin and KSP versions in README.md

## Version model
- ktConfig is the version used by every published project
- ktConfigBukkit and ktConfigFabric are the consumer-facing README versions
- a non-SNAPSHOT project release must match both README versions, preventing release-time drift

## Verification
- python -m unittest discover -s scripts/tests
- python scripts/sync_readme_versions.py --check
- gradlew.bat help --no-daemon
- gradlew.bat build check --no-daemon